### PR TITLE
Add StreamServer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - lcov
       - libpcap-dev
       - libboost-program-options-dev
+      - libboost-system-dev
 
 env:
   global:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ configure_file(
 # Overpass uses boost for parsing command-line parameters.
 find_package(Boost REQUIRED COMPONENTS
 	program_options
+	system
 )
 
 # Overpass uses libtins for packet processing.
@@ -27,6 +28,8 @@ include_directories(
 )
 
 set(OVERPASS_HEADERS
+	${PROJECT_SOURCE_DIR}/include/stream_server.h
+	${PROJECT_SOURCE_DIR}/include/types.h
 	${PROJECT_SOURCE_DIR}/include/virtual_interface.h
 )
 

--- a/include/stream_server.h
+++ b/include/stream_server.h
@@ -1,0 +1,211 @@
+#ifndef STREAM_SERVER_H
+#define STREAM_SERVER_H
+
+#include <memory>
+#include <iostream>
+
+#include <boost/system/error_code.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/asio/io_service.hpp>
+
+#include "types.h"
+
+namespace Overpass
+{
+	typedef std::function<void (const SharedBuffer&)> ReadCallback;
+
+	template <typename T>
+	class StreamServer;
+
+	template <typename T>
+	std::shared_ptr<StreamServer<T>> makeStreamServer(
+	      const SharedIoService &ioService,
+	      ReadCallback callback,
+	      std::unique_ptr<T> socket,
+	      std::size_t bufferSize = 1500);
+
+	template <typename T>
+	using SharedStreamServer = std::shared_ptr<StreamServer<T>>;
+
+	/*!
+	 * \brief The StreamServer class acts like a server for stream descriptors.
+	 */
+	template <typename T>
+	class StreamServer :
+	      public std::enable_shared_from_this<StreamServer<T>>
+	{
+		public:
+			/*!
+			 * \brief StreamServer constructor
+			 *
+			 * \param[in,out] ioService
+			 * IO service used for running the server.
+			 *
+			 * \param[in] callback
+			 * Function to be called when new data has been read from the
+			 * descriptor.
+			 *
+			 * \param[in] socket
+			 * Stream descriptor-like object.
+			 *
+			 * \param[in] bufferSize
+			 * How large of a buffer size to support (this is the package size).
+			 */
+			StreamServer(const SharedIoService &ioService,
+			             ReadCallback callback,
+			             std::unique_ptr<T> socket,
+			             std::size_t bufferSize = 1500):
+			   m_ioService(ioService),
+			   m_callback(callback),
+			   m_bufferSize(bufferSize),
+			   m_socket(std::move(socket))
+			{
+			}
+
+			/*!
+			 * \brief Write data to descriptor.
+			 *
+			 * \param[in] buffer
+			 * Buffer containing data to be written.
+			 *
+			 * This function will return immediately. It will do nothing until the
+			 * IO service is up and running (i.e. it queues up work to be done).
+			 */
+			void write(const Overpass::SharedBuffer &buffer) const
+			{
+				boost::asio::async_write(m_socket,
+				                         boost::asio::buffer(*buffer),
+				                         std::bind(&StreamServer::handleWrite,
+				                                   this->shared_from_this(),
+				                                   std::placeholders::_1,
+				                                   std::placeholders::_2));
+			}
+
+			friend std::shared_ptr<StreamServer> makeStreamServer<T>(
+			      const SharedIoService &ioService,
+			      ReadCallback callback,
+			      std::unique_ptr<T> socket,
+			      std::size_t bufferSize);
+
+		private:
+
+			/*!
+			 * \brief Start reading from the descriptor.
+			 *
+			 * This function will return immediately. It will do nothing until the
+			 * IO service is up and running (i.e. it queues up work to be done).
+			 */
+			void beginReading() const
+			{
+				Overpass::SharedBuffer buffer(new Overpass::Buffer(m_bufferSize));
+
+				m_socket->async_read_some(boost::asio::buffer(*buffer),
+				                          std::bind(&StreamServer::handleRead,
+				                                    this->shared_from_this(),
+				                                    buffer,
+				                                    std::placeholders::_1,
+				                                    std::placeholders::_2));
+			}
+
+			/*!
+			 * \brief Handle a completed read from the descriptor.
+			 *
+			 * \param[in] buffer
+			 * Buffer that was read (note that it's not necessarily full, check
+			 * bytesRead).
+			 *
+			 * \param[in] error
+			 * Error that occurred during reading (if any).
+			 *
+			 * \param[in] bytesRead
+			 * The number of bytes read during the operation (if any).
+			 */
+			void handleRead(Overpass::SharedBuffer buffer,
+			                const boost::system::error_code &error,
+			                std::size_t bytesRead) const
+			{
+				if (error)
+				{
+					std::cerr << "Error reading: " << error << std::endl;
+					return;
+				}
+
+				if (bytesRead == 0)
+				{
+					std::cerr << "Received zero bytes?" << std::endl;
+					return;
+				}
+
+				// We got something: dispatch callback with buffer.
+				m_ioService->post(std::bind(m_callback, buffer));
+
+				// Read some more.
+				beginReading();
+			}
+
+			/*!
+			 * \brief Handle a completed write to the descriptor.
+			 *
+			 * \param[in] error
+			 * Error that occurred during writing (if any).
+			 *
+			 * \param[in] bytesWritten
+			 * The number of bytes written during the operation (if any).
+			 */
+			void handleWrite(const boost::system::error_code &error,
+			                 std::size_t bytesWritten) const
+			{
+				if (error)
+				{
+					std::cerr << "Error writing: " << error << std::endl;
+				}
+
+				if (bytesWritten == 0)
+				{
+					std::cerr << "Wrote zero bytes?" << std::endl;
+				}
+			}
+
+		private:
+			SharedIoService m_ioService;
+			ReadCallback m_callback;
+			std::size_t m_bufferSize;
+			std::unique_ptr<T> m_socket;
+	};
+
+	/*!
+	 * \brief Create a new StreamServer and start it.
+	 *
+	 * \param[in,out] ioService
+	 * IO service used for running the server.
+	 *
+	 * \param[in] callback
+	 * Function to be called when new data has been read from the
+	 * descriptor.
+	 *
+	 * \param[in] socket
+	 * Stream descriptor-like object.
+	 *
+	 * \param[in] bufferSize
+	 * How large of a buffer size to support (this is the package size).
+	 */
+	template <typename T>
+	std::shared_ptr<StreamServer<T>> makeStreamServer(
+	      const SharedIoService &ioService,
+	      ReadCallback callback,
+	      std::unique_ptr<T> socket,
+	      std::size_t bufferSize)
+	{
+		auto communicator = std::make_shared<StreamServer<T> >(
+		                       ioService, callback, std::move(socket),
+		                       bufferSize);
+
+		// Ideally the constructor would do this, but it can't as shared_from_this
+		// can only be used once at least one shared pointer is pointing to the
+		// object in question (in this case, the communicator).
+		communicator->beginReading();
+		return communicator;
+	}
+}
+
+#endif // STREAM_SERVER_H

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,25 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <vector>
+#include <memory>
+#include <cstdint>
+#include <functional>
+
+namespace boost
+{
+	namespace asio
+	{
+		class io_service;
+	}
+}
+
+namespace Overpass
+{
+	typedef std::vector<uint8_t> Buffer;
+	typedef std::shared_ptr<Buffer> SharedBuffer;
+
+	typedef std::shared_ptr<boost::asio::io_service> SharedIoService;
+}
+
+#endif // TYPES_H

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,12 @@
 add_executable(unit-tests
 	${PROJECT_SOURCE_DIR}/tests/unit/src/main.cpp
+	${PROJECT_SOURCE_DIR}/tests/unit/src/test_stream_server.cpp
+	${PROJECT_SOURCE_DIR}/tests/unit/src/test_version.cpp
 )
 
 target_link_libraries(unit-tests
 	overpass
 	gmock
 	gmock_main
+	${Boost_LIBRARIES}
 )

--- a/tests/unit/src/test_stream_server.cpp
+++ b/tests/unit/src/test_stream_server.cpp
@@ -1,0 +1,186 @@
+#include <thread>
+#include <condition_variable>
+#include <chrono>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+
+#include "stream_server.h"
+
+class FakeStreamDescriptor
+{
+	public:
+		FakeStreamDescriptor(const Overpass::SharedIoService &ioService) :
+		   m_ioService(ioService)
+		{
+		}
+
+		MOCK_METHOD2(async_write_some, void(
+		                const boost::asio::const_buffers_1&,
+		                std::function<void (boost::system::error_code,
+		                                    std::size_t)>));
+
+	protected:
+		Overpass::SharedIoService m_ioService;
+};
+
+class FakeStreamDescriptorReadSuccess : public FakeStreamDescriptor
+{
+	public:
+		FakeStreamDescriptorReadSuccess(const Overpass::SharedIoService &ioService) :
+		   FakeStreamDescriptor(ioService)
+		{
+		}
+
+		void async_read_some(
+		      boost::asio::mutable_buffers_1 buffers,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([buffers, callback](){
+				// Make sure that there's room for the single byte we're about to
+				// write into the buffer.
+				ASSERT_LT(1, boost::asio::buffer_size(buffers));
+				Overpass::Buffer buffer{0xff};
+				memcpy(boost::asio::buffer_cast<void *>(buffers),
+				       buffer.data(),
+				       1);
+				callback(boost::system::error_code(), 1);
+			});
+		}
+};
+
+class FakeStreamDescriptorReadError : public FakeStreamDescriptor
+{
+	public:
+		FakeStreamDescriptorReadError(const Overpass::SharedIoService &ioService) :
+		   FakeStreamDescriptor(ioService)
+		{
+		}
+
+		void async_read_some(
+		      boost::asio::mutable_buffers_1 /*buffers*/,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([callback](){
+				callback(boost::system::error_code(), 0);
+			});
+		}
+};
+
+class FakeStreamDescriptorReadNothing : public FakeStreamDescriptor
+{
+	public:
+		FakeStreamDescriptorReadNothing(const Overpass::SharedIoService &ioService) :
+		   FakeStreamDescriptor(ioService)
+		{
+		}
+
+		void async_read_some(
+		      boost::asio::mutable_buffers_1 /*buffers*/,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([callback](){
+				using boost::system::errc::make_error_code;
+				callback(make_error_code(
+				            boost::system::errc::operation_canceled), 0);
+			});
+		}
+};
+
+TEST(StreamServer, ReadCallback)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const Overpass::SharedBuffer &buffer)
+	{
+		EXPECT_LT(1, buffer->size());
+		EXPECT_EQ(0xff, buffer->at(0));
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeStreamDescriptorReadSuccess> socket(
+	         new FakeStreamDescriptorReadSuccess(ioService));
+
+	auto streamServer = Overpass::makeStreamServer(ioService, callback, std::move(socket));
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::no_timeout, status) << "Unexpectedly timed out";
+	ioService->stop();
+	thread.join();
+}
+
+TEST(StreamServer, ReadError)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const Overpass::SharedBuffer &/*buffer*/)
+	{
+		FAIL() << "Callback was unexpectedly called";
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeStreamDescriptorReadError> socket(
+	         new FakeStreamDescriptorReadError(ioService));
+
+	auto streamServer = Overpass::makeStreamServer(ioService, callback, std::move(socket));
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::timeout, status) << "Unexpectedly DIDN'T timed out";
+	ioService->stop();
+	thread.join();
+}
+
+TEST(StreamServer, ReadNothing)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const Overpass::SharedBuffer &/*buffer*/)
+	{
+		FAIL() << "Callback was unexpectedly called";
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeStreamDescriptorReadNothing> socket(
+	         new FakeStreamDescriptorReadNothing(ioService));
+
+	auto streamServer = Overpass::makeStreamServer(ioService, callback, std::move(socket));
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::timeout, status) << "Unexpectedly DIDN'T timed out";
+	ioService->stop();
+	thread.join();
+}

--- a/tests/unit/src/test_version.cpp
+++ b/tests/unit/src/test_version.cpp
@@ -1,0 +1,14 @@
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "version.h"
+
+TEST(Version, VersionString)
+{
+	std::stringstream stream;
+	stream << LIBOVERPASS_VERSION_MAJOR << "."
+	       << LIBOVERPASS_VERSION_MINOR << "."
+	       << LIBOVERPASS_VERSION_PATCH;
+	EXPECT_EQ(stream.str(), Overpass::version());
+}


### PR DESCRIPTION
The StreamServer is used to communicate with stream decriptors, like that corresponding to the virtual interface on Linux (and hopefully other platforms).