### PR TITLE
Add DatagramServer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ include_directories(
 )
 
 set(OVERPASS_HEADERS
+	${PROJECT_SOURCE_DIR}/include/datagram_server.h
+	${PROJECT_SOURCE_DIR}/include/internal/datagram_server_private.h
 	${PROJECT_SOURCE_DIR}/include/stream_server.h
 	${PROJECT_SOURCE_DIR}/include/types.h
 	${PROJECT_SOURCE_DIR}/include/virtual_interface.h

--- a/include/datagram_server.h
+++ b/include/datagram_server.h
@@ -1,0 +1,66 @@
+#ifndef DATAGRAM_SERVER_H
+#define DATAGRAM_SERVER_H
+
+#include <boost/noncopyable.hpp>
+
+#include "types.h"
+#include "internal/datagram_server_private.h"
+
+namespace Overpass
+{
+	/*!
+	 * \brief The DatagramServer class is a server for datagram sockets.
+	 */
+	template <typename T>
+	class DatagramServer: private boost::noncopyable
+	{
+		public:
+			typedef typename internal::DatagramServerPrivate<T>::ReadCallback ReadCallback;
+
+			/*!
+			 * \brief DatagramServer constructor.
+			 *
+			 * \param[in,out] ioService
+			 * IO service used for running the server.
+			 *
+			 * \param[in] socket
+			 * Datagram socket-like object.
+			 *
+			 * \param[in] callback
+			 * Function to be called when new data has been read from the socket.
+			 *
+			 * \param[in] bufferSize
+			 * How large of a buffer size to support (this is the packet size).
+			 */
+			DatagramServer(const SharedIoService &ioService,
+			               std::unique_ptr<T> socket, ReadCallback callback,
+			               std::size_t bufferSize = 1500) :
+			   m_data(new internal::DatagramServerPrivate<T>(
+			             ioService, std::move(socket), callback, bufferSize))
+			{
+				m_data->beginReading();
+			}
+
+			/*!
+			 * \brief Send data over the socket to a specific endpoint.
+			 *
+			 * \param[in] destination
+			 * Where to send the data.
+			 *
+			 * \param[in] buffer
+			 * The data to send.
+			 */
+			void sendTo(const typename T::endpoint &destination,
+			            const SharedBuffer &buffer) const
+			{
+				m_data->sendTo(destination, buffer);
+			}
+
+		private:
+			// Using a shared_ptr instead of unique_ptr because of
+			// enable_shared_from_this.
+			std::shared_ptr<internal::DatagramServerPrivate<T>> m_data;
+	};
+}
+
+#endif // DATAGRAM_SERVER_H

--- a/include/internal/datagram_server_private.h
+++ b/include/internal/datagram_server_private.h
@@ -1,0 +1,136 @@
+#ifndef DATAGRAM_SERVER_PRIVATE_H
+#define DATAGRAM_SERVER_PRIVATE_H
+
+#include <iostream>
+
+namespace Overpass
+{
+	namespace internal
+	{
+		/*!
+		 * \brief The DatagramServerPrivate class is a server for datagram
+		 *        sockets.
+		 */
+		template <typename T>
+		class DatagramServerPrivate :
+		      public std::enable_shared_from_this<DatagramServerPrivate<T>>
+		{
+			public:
+				typedef std::function<void (
+				      const typename T::endpoint&, const SharedBuffer&)> ReadCallback;
+
+				/*!
+				 * \brief DatagramServerPrivate constructor.
+				 *
+				 * \param[in,out] ioService
+				 * IO service used for running the server.
+				 *
+				 * \param[in] socket
+				 * Datagram socket-like object.
+				 *
+				 * \param[in] callback
+				 * Function to be called when new data has been received from the
+				 * socket.
+				 *
+				 * \param[in] bufferSize
+				 * How large of a buffer size to support (this is the packet size).
+				 */
+				DatagramServerPrivate(const SharedIoService &ioService,
+				                      std::unique_ptr<T> socket,
+				                      ReadCallback callback,
+				                      std::size_t bufferSize) :
+				   m_ioService(ioService),
+				   m_callback(callback),
+				   m_socket(std::move(socket)),
+				   m_bufferSize(bufferSize)
+				{
+				}
+
+				/*!
+				 * \brief Start reading from the socket.
+				 *
+				 * This function will return immediately. It will do nothing until
+				 * the IO service is up and running (i.e. it queues up work to be
+				 * done).
+				 */
+				void beginReading()
+				{
+					SharedBuffer buffer(new Overpass::Buffer(m_bufferSize));
+
+					// Allocate a new endpoint to hold the sender's information.
+					std::shared_ptr<typename T::endpoint> endpoint(new typename T::endpoint);
+
+					m_socket->async_receive_from(
+					         boost::asio::buffer(*buffer), *endpoint,
+					         std::bind(&DatagramServerPrivate::handleRead,
+					                   this->shared_from_this(), endpoint, buffer,
+					                   std::placeholders::_1, std::placeholders::_2));
+				}
+
+				/*!
+				 * \brief Send data to destination over socket.
+				 *
+				 * \param[in] destination
+				 * Where to send the data.
+				 *
+				 * \param[in] buffer
+				 * The data to send.
+				 */
+				void sendTo(const typename T::endpoint &destination,
+				            const SharedBuffer &buffer)
+				{
+					m_socket->send_to(boost::asio::buffer(*buffer), destination);
+				}
+
+			private:
+				/*!
+				 * \brief Handle a completed read from the socket.
+				 *
+				 * \param[in] sender
+				 * Who sent the data we just received.
+				 *
+				 * \param[in] buffer
+				 * Buffer that was read (note that it's not necessarily full, check
+				 * bytesRead).
+				 *
+				 * \param[in] error
+				 * Error that occurred during reading (if any).
+				 *
+				 * \param[in] bytesRead
+				 * The number of bytes read during the operation (if any).
+				 */
+				void handleRead(
+				      std::shared_ptr<typename T::endpoint> sender,
+				      SharedBuffer buffer,
+				      const boost::system::error_code &error,
+				      std::size_t bytesRead)
+				{
+					if (error)
+					{
+						std::cerr << "Error reading: " << error << std::endl;
+						return;
+					}
+
+					if (bytesRead == 0)
+					{
+						std::cerr << "Received zero bytes?" << std::endl;
+						return;
+					}
+
+					// We got something: dispatch callback with buffer.
+					m_ioService->post(std::bind(m_callback, *sender, buffer));
+
+					// Read some more.
+					beginReading();
+				}
+
+			private:
+				SharedIoService m_ioService;
+				ReadCallback m_callback;
+				std::unique_ptr<T> m_socket;
+				std::size_t m_bufferSize;
+		};
+	}
+}
+
+#endif // DATAGRAM_SERVER_PRIVATE_H

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(unit-tests
 	${PROJECT_SOURCE_DIR}/tests/unit/src/main.cpp
+	${PROJECT_SOURCE_DIR}/tests/unit/src/test_datagram_server.cpp
 	${PROJECT_SOURCE_DIR}/tests/unit/src/test_stream_server.cpp
 	${PROJECT_SOURCE_DIR}/tests/unit/src/test_version.cpp
 )

--- a/tests/unit/src/test_datagram_server.cpp
+++ b/tests/unit/src/test_datagram_server.cpp
@@ -1,0 +1,213 @@
+#include <thread>
+#include <condition_variable>
+#include <chrono>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+
+#include "datagram_server.h"
+
+class FakeDatagramSocket
+{
+	public:
+		typedef std::string endpoint;
+
+		FakeDatagramSocket(const Overpass::SharedIoService &ioService) :
+		   m_ioService(ioService)
+		{
+		}
+
+	protected:
+		Overpass::SharedIoService m_ioService;
+};
+
+class FakeDatagramSocketReceiveSuccess : public FakeDatagramSocket
+{
+	public:
+		FakeDatagramSocketReceiveSuccess(
+		      const Overpass::SharedIoService &ioService) :
+		   FakeDatagramSocket(ioService)
+		{
+		}
+
+		void async_receive_from(
+		      boost::asio::mutable_buffers_1 buffers,
+		      std::string &endpoint,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([buffers, callback, &endpoint](){
+				// Make sure that there's room for the single byte we're about to
+				// write into the buffer.
+				ASSERT_LT(1, boost::asio::buffer_size(buffers));
+				Overpass::Buffer buffer{0xff};
+				memcpy(boost::asio::buffer_cast<void *>(buffers),
+				       buffer.data(),
+				       1);
+				endpoint = "test-sender";
+				callback(boost::system::error_code(), 1);
+			});
+		}
+};
+
+class FakeDatagramSocketReceiveError : public FakeDatagramSocket
+{
+	public:
+		FakeDatagramSocketReceiveError(
+		      const Overpass::SharedIoService &ioService) :
+		   FakeDatagramSocket(ioService)
+		{
+		}
+
+		void async_receive_from(
+		      boost::asio::mutable_buffers_1 buffers,
+		      std::string &endpoint,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([buffers, callback, &endpoint](){
+				// Make sure that there's room for the single byte we're about to
+				// write into the buffer.
+				ASSERT_LT(1, boost::asio::buffer_size(buffers));
+				Overpass::Buffer buffer{0xff};
+				memcpy(boost::asio::buffer_cast<void *>(buffers),
+				       buffer.data(),
+				       1);
+				endpoint = "test-sender";
+				using boost::system::errc::make_error_code;
+				callback(make_error_code(
+				            boost::system::errc::operation_canceled), 0);
+			});
+		}
+};
+
+class FakeDatagramSocketReceiveNothing : public FakeDatagramSocket
+{
+	public:
+		FakeDatagramSocketReceiveNothing(
+		      const Overpass::SharedIoService &ioService) :
+		   FakeDatagramSocket(ioService)
+		{
+		}
+
+		void async_receive_from(
+		      boost::asio::mutable_buffers_1 buffers,
+		      std::string &endpoint,
+		      std::function<void (
+		         boost::system::error_code, std::size_t)> callback)
+		{
+			m_ioService->post([buffers, callback, &endpoint](){
+				// Make sure that there's room for the single byte we're about to
+				// write into the buffer.
+				ASSERT_LT(1, boost::asio::buffer_size(buffers));
+				Overpass::Buffer buffer{0xff};
+				memcpy(boost::asio::buffer_cast<void *>(buffers),
+				       buffer.data(),
+				       1);
+				endpoint = "test-sender";
+				callback(boost::system::error_code(), 0);
+
+			});
+		}
+};
+
+TEST(DatagramServer, ReadCallback)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const std::string &endpoint, const Overpass::SharedBuffer &buffer)
+	{
+		EXPECT_EQ("test-sender", endpoint);
+		EXPECT_LT(1, buffer->size());
+		EXPECT_EQ(0xff, buffer->at(0));
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeDatagramSocketReceiveSuccess> socket(
+	         new FakeDatagramSocketReceiveSuccess(ioService));
+
+	auto server = std::make_shared<Overpass::DatagramServer<FakeDatagramSocketReceiveSuccess>>(
+	                 ioService, std::move(socket), callback);
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::no_timeout, status) << "Unexpectedly timed out";
+	ioService->stop();
+	thread.join();
+}
+
+TEST(DatagramServer, ReadError)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const std::string &/*endpoint*/,
+	                const Overpass::SharedBuffer &/*buffer*/)
+	{
+		FAIL() << "Callback was unexpectedly called";
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeDatagramSocketReceiveError> socket(
+	         new FakeDatagramSocketReceiveError(ioService));
+
+	auto server = std::make_shared<Overpass::DatagramServer<FakeDatagramSocketReceiveError>>(
+	                 ioService, std::move(socket), callback);
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::timeout, status) << "Unexpectedly DIDN'T timed out";
+	ioService->stop();
+	thread.join();
+}
+
+TEST(DatagramServer, ReadNothing)
+{
+	Overpass::SharedIoService ioService(new boost::asio::io_service);
+	using boost::system::error_code;
+
+	std::mutex mutex;
+	std::condition_variable condition;
+
+	auto callback = [&](const std::string &/*endpoint*/,
+	                const Overpass::SharedBuffer &/*buffer*/)
+	{
+		FAIL() << "Callback was unexpectedly called";
+		ioService->stop();
+		std::unique_lock<std::mutex> lock(mutex);
+		condition.notify_one();
+	};
+
+	std::unique_ptr<FakeDatagramSocketReceiveNothing> socket(
+	         new FakeDatagramSocketReceiveNothing(ioService));
+
+	auto server = std::make_shared<Overpass::DatagramServer<FakeDatagramSocketReceiveNothing>>(
+	                 ioService, std::move(socket), callback);
+
+	std::thread thread([&ioService](){ioService->run();});
+
+	std::unique_lock<std::mutex> lock(mutex);
+	auto status = condition.wait_for(lock, std::chrono::seconds(1));
+	EXPECT_EQ(std::cv_status::timeout, status) << "Unexpectedly DIDN'T timed out";
+	ioService->stop();
+	thread.join();
+}

--- a/tests/unit/src/test_stream_server.cpp
+++ b/tests/unit/src/test_stream_server.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/asio/buffer.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/asio/posix/stream_descriptor.hpp>
 
 #include "stream_server.h"
 
@@ -68,7 +67,9 @@ class FakeStreamDescriptorReadError : public FakeStreamDescriptor
 		         boost::system::error_code, std::size_t)> callback)
 		{
 			m_ioService->post([callback](){
-				callback(boost::system::error_code(), 0);
+				using boost::system::errc::make_error_code;
+				callback(make_error_code(
+				            boost::system::errc::operation_canceled), 0);
 			});
 		}
 };
@@ -87,9 +88,7 @@ class FakeStreamDescriptorReadNothing : public FakeStreamDescriptor
 		         boost::system::error_code, std::size_t)> callback)
 		{
 			m_ioService->post([callback](){
-				using boost::system::errc::make_error_code;
-				callback(make_error_code(
-				            boost::system::errc::operation_canceled), 0);
+				callback(boost::system::error_code(), 0);
 			});
 		}
 };


### PR DESCRIPTION
The DatagramServer is used to communicate with datagram sockets (e.g. UDP sockets).