### PR TITLE
Add Router.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,14 @@ include_directories(
 set(OVERPASS_HEADERS
 	${PROJECT_SOURCE_DIR}/include/datagram_server.h
 	${PROJECT_SOURCE_DIR}/include/internal/datagram_server_private.h
+	${PROJECT_SOURCE_DIR}/include/router.h
 	${PROJECT_SOURCE_DIR}/include/stream_server.h
 	${PROJECT_SOURCE_DIR}/include/types.h
 	${PROJECT_SOURCE_DIR}/include/virtual_interface.h
 )
 
 set(OVERPASS_SOURCES
+	${PROJECT_SOURCE_DIR}/src/router.cpp
 	${PROJECT_SOURCE_DIR}/src/version.cpp
 	${PROJECT_SOURCE_DIR}/src/virtual_interface_implementations/linux.cpp
 )

--- a/include/router.h
+++ b/include/router.h
@@ -1,0 +1,86 @@
+#ifndef ROUTER_H
+#define ROUTER_H
+
+#include <map>
+
+#include <boost/asio/ip/udp.hpp>
+
+#include "types.h"
+
+namespace Tins
+{
+	class IP;
+}
+
+namespace Overpass
+{
+	/*!
+	 * \brief The Router class shuffles packets between the external and virtual
+	 *        interfaces.
+	 */
+	class Router
+	{
+		public:
+			typedef std::function<void (
+			      const boost::asio::ip::udp::endpoint &,
+			      const Overpass::SharedBuffer &)> ExternalSender;
+			typedef std::function<void (
+			      const Overpass::SharedBuffer &)> VirtualSender;
+
+			/*!
+			 * \brief Router constructor.
+			 *
+			 * \param[in] externalSender
+			 * Function to call in order to send a packet over the external
+			 * interface.
+			 *
+			 * \param[in] virtualSender
+			 * Function to call in order to send a packet over the virtual
+			 * interface.
+			 */
+			Router(ExternalSender externalSender, VirtualSender virtualSender);
+
+			/*!
+			 * \brief Add a known client, mapping Overpass address to external
+			 *        address.
+			 *
+			 * \param[in] overpassAddress
+			 * Client's IP address on the Overpass network.
+			 *
+			 * \param[in] externalAddress
+			 * Client's external IP address, on which the Overpass client is
+			 * (hopefully) listening.
+			 */
+			void addKnownClient(
+			      const boost::asio::ip::address &overpassAddress,
+			      const boost::asio::ip::address &externalAddress);
+
+			/*!
+			 * \brief Route a packet from the virtual interface to a known client
+			 *        over the external interface.
+			 *
+			 * \param[in] packet
+			 * The packet to be routed.
+			 */
+			void handlePacketFromVirtual(Tins::IP &packet);
+
+			/*!
+			 * \brief Route a packet from the external interface to the virtual
+			 *        interface.
+			 *
+			 * \param[in] packet
+			 * The packet to be routed.
+			 */
+			void handlePacketFromExternal(Tins::IP &packet);
+
+		private:
+			ExternalSender m_externalSender;
+			VirtualSender m_virtualSender;
+
+			typedef std::map<boost::asio::ip::address, boost::asio::ip::address>
+			ClientMap;
+			ClientMap m_knownClients;
+	};
+}
+
+#endif // ROUTER_H

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+
+#include <boost/asio/detail/socket_ops.hpp>
+
+#include <tins/ip.h>
+#include <tins/udp.h>
+
+#include "router.h"
+
+using namespace Overpass;
+
+Router::Router(ExternalSender externalSender, VirtualSender virtualSender) :
+   m_externalSender(externalSender),
+   m_virtualSender(virtualSender)
+{
+}
+
+void Router::addKnownClient(const boost::asio::ip::address &overpassAddress,
+                            const boost::asio::ip::address &externalAddress)
+{
+	m_knownClients[overpassAddress] = externalAddress;
+}
+
+void Router::handlePacketFromVirtual(Tins::IP &packet)
+{
+	// Extract the destination of this packet
+	boost::asio::ip::address_v4 destination(
+	         boost::asio::detail::socket_ops::network_to_host_long(
+	            packet.dst_addr()));
+
+	// Coming from the virtual interface, the destination will be an IP address
+	// on the Overpass network. We need to look it up in our routing table to
+	// determine where this packet actually needs to go.
+	auto clientAddress = m_knownClients.at(destination);
+
+	auto buffer = std::make_shared<Overpass::Buffer>(
+	                 std::move(packet.serialize()));
+	boost::asio::ip::udp::endpoint endpoint(clientAddress, 1234);
+	m_externalSender(endpoint, buffer);
+}
+
+void Router::handlePacketFromExternal(Tins::IP &packet)
+{
+	// This packet is destined for something listening on our virtual interface.
+	// Send it there.
+	auto buffer = std::make_shared<Overpass::Buffer>(
+	                 std::move(packet.serialize()));
+	m_virtualSender(buffer);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ if(LCOV_FOUND)
 
 		# Combine and filter the initial and tested coverage reports
 		COMMAND ${LCOV} -q -a ${INITIAL_COVERAGE_FILE} -a ${TESTED_COVERAGE_FILE} -o total.coverage
-		COMMAND ${LCOV} -q -r total.coverage 'tests/*' '/usr/*' -o ${FINAL_COVERAGE_FILE}
+		COMMAND ${LCOV} -q -r total.coverage 'tests/*' '/usr/*' '*libtins*' -o ${FINAL_COVERAGE_FILE}
 
 		DEPENDS run-tests
 	)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(unit-tests
 	${PROJECT_SOURCE_DIR}/tests/unit/src/main.cpp
 	${PROJECT_SOURCE_DIR}/tests/unit/src/test_datagram_server.cpp
+	${PROJECT_SOURCE_DIR}/tests/unit/src/test_router.cpp
 	${PROJECT_SOURCE_DIR}/tests/unit/src/test_stream_server.cpp
 	${PROJECT_SOURCE_DIR}/tests/unit/src/test_version.cpp
 )

--- a/tests/unit/src/test_router.cpp
+++ b/tests/unit/src/test_router.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <tins/ip.h>
+#include <tins/udp.h>
+#include <tins/rawpdu.h>
+
+#include "router.h"
+
+// Test that a packet from the external interface gets sent to the virtual
+// interface.
+TEST(Router, FromExternal)
+{
+	uint16_t destinationPort = 1000;
+	uint16_t sourcePort = 1001;
+
+	auto externalSender = [&](const boost::asio::ip::udp::endpoint&,
+	                    const Overpass::SharedBuffer&)
+	{
+		FAIL() << "Router unexpectedly sent data to the external interface";
+	};
+
+	bool virtualSenderCalled = false;
+	auto virtualSender = [&](const Overpass::SharedBuffer &buffer)
+	{
+		virtualSenderCalled = true;
+
+		// Reconstruct the IP packet from the buffer
+		Tins::IP packet(buffer->data(), buffer->size());
+		const Tins::UDP udpPacket = packet.rfind_pdu<Tins::UDP>();
+
+		// Verify that this packet is the nested one.
+		EXPECT_EQ(destinationPort, udpPacket.dport());
+		EXPECT_EQ(sourcePort, udpPacket.sport());
+
+		const Tins::RawPDU& raw = udpPacket.rfind_pdu<Tins::RawPDU>();
+		const Tins::RawPDU::payload_type &payload = raw.payload();
+		std::string payloadString(reinterpret_cast<const char*>(
+		                             payload.data()), payload.size());
+		EXPECT_EQ("test-packet", payloadString);
+	};
+
+	Overpass::Router router(externalSender, virtualSender);
+
+	Tins::IP packet = Tins::IP("11.11.11.2") /
+	                  Tins::UDP(destinationPort, sourcePort) /
+	                  Tins::RawPDU("test-packet");
+
+	router.handlePacketFromExternal(packet);
+	EXPECT_EQ(true, virtualSenderCalled)
+	      << "Expected virtual sender to be called";
+}
+
+// Test that a packet from the virtual interface gets sent to the correct client
+// over the external interface.
+TEST(Router, FromVirtual)
+{
+	uint16_t destinationPort = 1000;
+	uint16_t sourcePort = 1001;
+
+	auto overpassAddress = boost::asio::ip::address::from_string("11.11.11.2");
+	auto externalAddress = boost::asio::ip::address::from_string("1.2.3.4");
+
+	Tins::IP packet = Tins::IP(overpassAddress.to_string()) /
+	                  Tins::UDP(destinationPort, sourcePort) /
+	                  Tins::RawPDU("test-packet");
+
+	bool externalSenderCalled = false;
+	auto externalSender = [&](const boost::asio::ip::udp::endpoint &destination,
+	                    const Overpass::SharedBuffer &buffer)
+	{
+		externalSenderCalled = true;
+
+		// Verify the destination is the client's external IP address.
+		EXPECT_EQ(externalAddress, destination.address());
+
+		// Reconstruct the packet from the buffer, and verify it's the one we
+		// sent.
+		Tins::IP ipPacket(buffer->data(), buffer->size());
+		const Tins::UDP &udpPacket = ipPacket.rfind_pdu<Tins::UDP>();
+
+		EXPECT_EQ(destinationPort, udpPacket.dport());
+		EXPECT_EQ(sourcePort, udpPacket.sport());
+
+		const Tins::RawPDU& raw = udpPacket.rfind_pdu<Tins::RawPDU>();
+		const Tins::RawPDU::payload_type &payload = raw.payload();
+		std::string payloadString(reinterpret_cast<const char*>(
+		                             payload.data()), payload.size());
+		EXPECT_EQ("test-packet", payloadString);
+	};
+
+	auto virtualSender = [&](const Overpass::SharedBuffer &buffer)
+	{
+		FAIL() << "Router unexpectedly sent data to the virtual interface";
+	};
+
+	Overpass::Router router(externalSender, virtualSender);
+	router.addKnownClient(overpassAddress, externalAddress);
+
+	router.handlePacketFromVirtual(packet);
+	EXPECT_EQ(true, externalSenderCalled)
+	      << "Expected external sender to be called";
+}


### PR DESCRIPTION
The Router is responsible for shuffling packets between the external and internal interfaces. It includes a dynamic routing table so packets can be routed to known Overpass clients.